### PR TITLE
fix: use temperature=1 for Kimi providers in model probe

### DIFF
--- a/lib/model-probe.ts
+++ b/lib/model-probe.ts
@@ -192,6 +192,10 @@ async function probeModelDirect(params: ProbeModelParams): Promise<DirectProbeRe
   if (!providerCfg?.baseUrl || !providerCfg.api || !providerCfg.apiKey) return null;
 
   const timeoutMs = params.timeoutMs ?? DEFAULT_MODEL_PROBE_TIMEOUT_MS;
+  // Kimi providers require temperature=1
+  const isKimiProvider = params.providerId === "kimi-coding" || params.providerId === "moonshot";
+  const temperature = isKimiProvider ? 1 : 0;
+
   const headers: Record<string, string> = {
     "content-type": "application/json",
     ...(providerCfg.headers || {}),
@@ -205,6 +209,7 @@ async function probeModelDirect(params: ProbeModelParams): Promise<DirectProbeRe
       model: params.modelId,
       max_tokens: 8,
       messages: [{ role: "user", content: "Reply with OK." }],
+      temperature,
     };
     const start = Date.now();
     try {
@@ -254,7 +259,7 @@ async function probeModelDirect(params: ProbeModelParams): Promise<DirectProbeRe
       model: params.modelId,
       messages: [{ role: "user", content: "Reply with OK." }],
       max_tokens: 8,
-      temperature: 0,
+      temperature,
     };
     const start = Date.now();
     try {


### PR DESCRIPTION
## Summary
- Use `temperature=1` when testing Kimi providers (kimi-coding and moonshot)
- Keep `temperature=0` for all other providers for deterministic test results

## Problem
Kimi models require `temperature=1` for proper responses during connectivity tests. Using `temperature=0` may cause test failures or unexpected behavior.

## Solution
Modified `probeModelDirect()` in `lib/model-probe.ts` to:
1. Detect if the provider is a Kimi provider (`kimi-coding` or `moonshot`)
2. Set `temperature=1` for Kimi providers, `temperature=0` for others
3. Apply the temperature setting to both `anthropic-messages` and `openai-completions` API types

## Testing
Tested with kimi-coding and moonshot providers - connectivity tests now pass with `temperature=1`.

🤖 Generated with [Claude Code](https://claude.ai/code)