### PR TITLE
fix: escape regex input and use safe JSON reader in config API

### DIFF
--- a/app/api/config/route.ts
+++ b/app/api/config/route.ts
@@ -4,6 +4,7 @@ import path from "path";
 import { getConfigCache, setConfigCache } from "@/lib/config-cache";
 import { OPENCLAW_CONFIG_PATH, OPENCLAW_HOME } from "@/lib/openclaw-paths";
 import { shouldHidePlatformChannel } from "@/lib/platforms";
+import { readJsonFileSync } from "@/lib/json";
 
 // 配置文件路径：优先使用 OPENCLAW_HOME 环境变量，否则默认 ~/.openclaw
 const CONFIG_PATH = OPENCLAW_CONFIG_PATH;
@@ -210,7 +211,8 @@ function getChannelDirectPeerIds(
   channel: string
 ): Record<string, string> {
   const map: Record<string, string> = {};
-  const pattern = new RegExp(`^agent:[^:]+:${channel}:direct:(.+)$`);
+  const safeChannel = channel.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const pattern = new RegExp(`^agent:[^:]+:${safeChannel}:direct:(.+)$`);
   for (const agentId of agentIds) {
     try {
       const sessions = sessionsMap.get(agentId);
@@ -262,8 +264,7 @@ export async function GET() {
   }
 
   try {
-    const raw = fs.readFileSync(CONFIG_PATH, "utf-8");
-    const config = JSON.parse(raw);
+    const config = readJsonFileSync(CONFIG_PATH);
 
     // 提取 agents 信息
     const defaults = config.agents?.defaults || {};


### PR DESCRIPTION
## Summary
- **Regex injection**: `getChannelDirectPeerIds()` passes the `channel` parameter directly into `new RegExp()`. A crafted channel name containing regex metacharacters (e.g., `.*`, `|`) could match unintended sessions or cause unexpected behavior. Fixed by escaping special characters before interpolation.
- **Raw JSON.parse**: Replaced bare `fs.readFileSync` + `JSON.parse` with the project's existing `readJsonFileSync` utility from `lib/json.ts` for consistent UTF-8 BOM handling and error semantics. Other files (e.g., `agent-activity/route.ts`) already use this utility.

## Changes
| File | Change |
|------|--------|
| `app/api/config/route.ts` | Escape regex metacharacters in `channel` before `new RegExp()` |
| `app/api/config/route.ts` | Replace `JSON.parse(fs.readFileSync(...))` with `readJsonFileSync()` |

## Test plan
- [ ] Verify `GET /api/config` returns expected data with normal channel names
- [ ] Test with a channel name containing regex metacharacters (e.g., `test.+channel`) and confirm it no longer matches unintended entries
- [ ] Run existing test suite to check for regressions