### PR TITLE
Release v3.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openclaw-bot-review",
-  "version": "1.0.0",
+  "version": "3.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openclaw-bot-review",
-      "version": "1.0.0",
+      "version": "3.0.0",
       "license": "MIT",
       "dependencies": {
         "@tailwindcss/postcss": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "name": "openclaw-bot-review",
-  "version": "1.0.0",
+  "version": "3.0.0",
   "private": true,
   "license": "MIT",
   "scripts": {
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "test": "vitest run"
+    "test": "vitest run __tests__ && node --test tests/*.test.mjs"
   },
   "dependencies": {
     "@tailwindcss/postcss": "^4.0.0",


### PR DESCRIPTION
## Summary

- bump application and lockfile versions to `3.0.0`
- run the Vitest and Node.js test suites with their matching runners

## Why

Prepare the repository for the `v3.0.0` release and make `npm test` return the correct status for the mixed test layout.

## Impact

There are no runtime behavior changes. This updates release metadata and the test command used by maintainers and CI.

## Validation

- `npm ci --no-audit --no-fund`
- `npm test` (Vitest: 21 passed, 3 skipped; Node.js: 21 passed)
- `npm run build`
