### PR TITLE
Refresh MiniMax provider metadata for MiniMax-M3 and regional endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ The dashboard includes built-in metadata for the following LLM providers, enabli
 
 | Provider | Models | API Type | Base URL |
 |----------|--------|----------|----------|
-| **[MiniMax](https://platform.minimax.io)** | `MiniMax-M2.7`, `MiniMax-M2.7-highspeed` | OpenAI-compatible | `https://api.minimax.io/v1` |
+| **[MiniMax](https://platform.minimax.io)** | `MiniMax-M3`, `MiniMax-M2.7`, `MiniMax-M2.7-highspeed` | OpenAI-compatible (global) / Anthropic-compatible | `https://api.minimax.io/v1` (global), `https://api.minimaxi.com/v1` (CN) |
 
 To use MiniMax with OpenClaw, add the following to your `models.json`:
 
@@ -119,6 +119,7 @@ To use MiniMax with OpenClaw, add the following to your `models.json`:
       "api": "openai-completions",
       "apiKey": "your-minimax-api-key",
       "models": [
+        { "id": "MiniMax-M3", "name": "MiniMax-M3" },
         { "id": "MiniMax-M2.7", "name": "MiniMax-M2.7" },
         { "id": "MiniMax-M2.7-highspeed", "name": "MiniMax-M2.7-highspeed" }
       ]
@@ -127,7 +128,13 @@ To use MiniMax with OpenClaw, add the following to your `models.json`:
 }
 ```
 
-For more details, see the [MiniMax API Reference](https://platform.minimax.io/docs/api-reference/text-openai-api).
+MiniMax exposes both OpenAI- and Anthropic-compatible endpoints, with regional
+variants: the global endpoint (`https://api.minimax.io/v1` and
+`https://api.minimax.io/anthropic`) and the China endpoint
+(`https://api.minimaxi.com/v1` and `https://api.minimaxi.com/anthropic`).
+`MiniMax-M3` supports a 1,000,000-token context window with text, image, and
+video inputs and adaptive/disabled thinking; `MiniMax-M2.7` has thinking always
+on. For more details, see the [MiniMax API Reference](https://platform.minimax.io/docs/api-reference/api-overview).
 
 ## Docker Deployment
 
@@ -231,7 +238,7 @@ npm run start
 
 | Provider | 模型 | API 类型 | Base URL |
 |----------|------|----------|----------|
-| **[MiniMax](https://platform.minimax.io)** | `MiniMax-M2.7`, `MiniMax-M2.7-highspeed` | OpenAI 兼容 | `https://api.minimax.io/v1` |
+| **[MiniMax](https://platform.minimax.io)** | `MiniMax-M3`, `MiniMax-M2.7`, `MiniMax-M2.7-highspeed` | OpenAI 兼容（全球）/ Anthropic 兼容 | `https://api.minimax.io/v1`（全球），`https://api.minimaxi.com/v1`（中国） |
 
 在 `models.json` 中添加 MiniMax 配置：
 
@@ -243,6 +250,7 @@ npm run start
       "api": "openai-completions",
       "apiKey": "your-minimax-api-key",
       "models": [
+        { "id": "MiniMax-M3", "name": "MiniMax-M3" },
         { "id": "MiniMax-M2.7", "name": "MiniMax-M2.7" },
         { "id": "MiniMax-M2.7-highspeed", "name": "MiniMax-M2.7-highspeed" }
       ]
@@ -251,7 +259,7 @@ npm run start
 }
 ```
 
-更多信息请参考 [MiniMax API 文档](https://platform.minimax.io/docs/api-reference/text-openai-api)。
+更多信息请参考 [MiniMax API 文档](https://platform.minimax.io/docs/api-reference/api-overview)。
 
 ## 作者联系方式（contact）
 小红书：[主页](https://xhslink.com/m/AsJKWgEBt1I) 

--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ npm run start
 
 | Provider | 模型 | API 类型 | Base URL |
 |----------|------|----------|----------|
-| **[MiniMax](https://platform.minimax.io)** | `MiniMax-M3`, `MiniMax-M2.7`, `MiniMax-M2.7-highspeed` | OpenAI 兼容（全球）/ Anthropic 兼容 | `https://api.minimax.io/v1`（全球），`https://api.minimaxi.com/v1`（中国） |
+| **[MiniMax](https://platform.minimax.io)** | `MiniMax-M3`, `MiniMax-M2.7`, `MiniMax-M2.7-highspeed` | OpenAI-compatible (global) / Anthropic-compatible | `https://api.minimax.io/v1` (global), `https://api.minimaxi.com/v1` (China) |
 
 在 `models.json` 中添加 MiniMax 配置：
 
@@ -259,7 +259,7 @@ npm run start
 }
 ```
 
-更多信息请参考 [MiniMax API 文档](https://platform.minimax.io/docs/api-reference/api-overview)。
+For more details, see the [MiniMax API documentation](https://platform.minimax.io/docs/api-reference/api-overview).
 
 ## 作者联系方式（contact）
 小红书：[主页](https://xhslink.com/m/AsJKWgEBt1I) 

--- a/__tests__/known-providers.test.ts
+++ b/__tests__/known-providers.test.ts
@@ -37,6 +37,12 @@ describe("getKnownProvider", () => {
     expect(m3!.contextWindow).toBe(1000000);
     expect(m3!.reasoning).toBe(true);
     expect(m3!.input).toEqual(["text", "image", "video"]);
+    expect(m3!.pricingUsdPerMillionTokens).toEqual({
+      input: 0.6,
+      output: 2.4,
+      cacheRead: 0.12,
+      cacheWrite: null,
+    });
     expect(m3!.thinking).toEqual(["adaptive", "disabled"]);
   });
 
@@ -48,6 +54,12 @@ describe("getKnownProvider", () => {
     expect(m27!.maxTokens).toBe(192000);
     expect(m27!.reasoning).toBe(true);
     expect(m27!.input).toEqual(["text"]);
+    expect(m27!.pricingUsdPerMillionTokens).toEqual({
+      input: 0.3,
+      output: 1.2,
+      cacheRead: 0.06,
+      cacheWrite: 0.375,
+    });
     expect(m27!.thinking).toEqual(["always_on"]);
   });
 
@@ -73,11 +85,13 @@ describe("MiniMax regional endpoints", () => {
     expect(globalRegion).toBeDefined();
     expect(globalRegion!.openaiBaseUrl).toBe("https://api.minimax.io/v1");
     expect(globalRegion!.anthropicBaseUrl).toBe("https://api.minimax.io/anthropic");
+    expect(globalRegion!.docsRoot).toBe("https://platform.minimax.io/docs");
 
     const cnRegion = regions.find((r) => r.region === "cn_zh");
     expect(cnRegion).toBeDefined();
     expect(cnRegion!.openaiBaseUrl).toBe("https://api.minimaxi.com/v1");
     expect(cnRegion!.anthropicBaseUrl).toBe("https://api.minimaxi.com/anthropic");
+    expect(cnRegion!.docsRoot).toBe("https://platform.minimaxi.com/docs");
   });
 });
 
@@ -88,6 +102,12 @@ describe("enrichModelMeta", () => {
     expect(enriched.contextWindow).toBe(1000000);
     expect(enriched.reasoning).toBe(true);
     expect(enriched.input).toEqual(["text", "image", "video"]);
+    expect(enriched.pricingUsdPerMillionTokens).toEqual({
+      input: 0.6,
+      output: 2.4,
+      cacheRead: 0.12,
+      cacheWrite: null,
+    });
     expect(enriched.thinking).toEqual(["adaptive", "disabled"]);
   });
 
@@ -98,6 +118,12 @@ describe("enrichModelMeta", () => {
     expect(enriched.maxTokens).toBe(192000);
     expect(enriched.reasoning).toBe(true);
     expect(enriched.input).toEqual(["text"]);
+    expect(enriched.pricingUsdPerMillionTokens).toEqual({
+      input: 0.3,
+      output: 1.2,
+      cacheRead: 0.06,
+      cacheWrite: 0.375,
+    });
     expect(enriched.thinking).toEqual(["always_on"]);
   });
 
@@ -109,6 +135,13 @@ describe("enrichModelMeta", () => {
       maxTokens: 50000,
       reasoning: true,
       input: ["text", "image"],
+      pricingUsdPerMillionTokens: {
+        input: 1,
+        output: 2,
+        cacheRead: 0.5,
+        cacheWrite: null,
+      },
+      thinking: ["disabled"],
     };
     const enriched = enrichModelMeta("minimax", model);
     expect(enriched.name).toBe("Custom Name");
@@ -116,6 +149,13 @@ describe("enrichModelMeta", () => {
     expect(enriched.maxTokens).toBe(50000);
     expect(enriched.reasoning).toBe(true);
     expect(enriched.input).toEqual(["text", "image"]);
+    expect(enriched.pricingUsdPerMillionTokens).toEqual({
+      input: 1,
+      output: 2,
+      cacheRead: 0.5,
+      cacheWrite: null,
+    });
+    expect(enriched.thinking).toEqual(["disabled"]);
   });
 
   it("fills in undefined fields while keeping defined ones", () => {

--- a/__tests__/known-providers.test.ts
+++ b/__tests__/known-providers.test.ts
@@ -8,6 +8,7 @@ describe("getKnownProvider", () => {
     expect(provider!.displayName).toBe("MiniMax");
     expect(provider!.api).toBe("openai-completions");
     expect(provider!.baseUrl).toBe("https://api.minimax.io/v1");
+    expect(provider!.anthropicBaseUrl).toBe("https://api.minimax.io/anthropic");
   });
 
   it("returns MiniMax provider metadata for case-insensitive match", () => {
@@ -21,33 +22,83 @@ describe("getKnownProvider", () => {
     expect(provider).toBeNull();
   });
 
-  it("includes both MiniMax models", () => {
+  it("includes MiniMax-M3, MiniMax-M2.7, and MiniMax-M2.7-highspeed models", () => {
     const provider = getKnownProvider("minimax");
-    expect(provider!.models).toHaveLength(2);
     const ids = provider!.models.map((m) => m.id);
+    expect(ids).toContain("MiniMax-M3");
     expect(ids).toContain("MiniMax-M2.7");
     expect(ids).toContain("MiniMax-M2.7-highspeed");
   });
 
-  it("MiniMax models have correct contextWindow and maxTokens", () => {
+  it("MiniMax-M3 has 1,000,000-token context, multimodal input, and adaptive/disabled thinking", () => {
     const provider = getKnownProvider("minimax");
-    for (const model of provider!.models) {
-      expect(model.contextWindow).toBe(204800);
-      expect(model.maxTokens).toBe(192000);
-      expect(model.reasoning).toBe(false);
-      expect(model.input).toEqual(["text"]);
-    }
+    const m3 = provider!.models.find((m) => m.id === "MiniMax-M3");
+    expect(m3).toBeDefined();
+    expect(m3!.contextWindow).toBe(1000000);
+    expect(m3!.reasoning).toBe(true);
+    expect(m3!.input).toEqual(["text", "image", "video"]);
+    expect(m3!.thinking).toEqual(["adaptive", "disabled"]);
+  });
+
+  it("MiniMax-M2.7 retains context window, text-only input, and marks reasoning always on", () => {
+    const provider = getKnownProvider("minimax");
+    const m27 = provider!.models.find((m) => m.id === "MiniMax-M2.7");
+    expect(m27).toBeDefined();
+    expect(m27!.contextWindow).toBe(204800);
+    expect(m27!.maxTokens).toBe(192000);
+    expect(m27!.reasoning).toBe(true);
+    expect(m27!.input).toEqual(["text"]);
+    expect(m27!.thinking).toEqual(["always_on"]);
+  });
+
+  it("MiniMax-M2.7-highspeed retains its non-reasoning text-only metadata", () => {
+    const provider = getKnownProvider("minimax");
+    const highspeed = provider!.models.find((m) => m.id === "MiniMax-M2.7-highspeed");
+    expect(highspeed).toBeDefined();
+    expect(highspeed!.contextWindow).toBe(204800);
+    expect(highspeed!.maxTokens).toBe(192000);
+    expect(highspeed!.reasoning).toBe(false);
+    expect(highspeed!.input).toEqual(["text"]);
+  });
+});
+
+describe("MiniMax regional endpoints", () => {
+  it("exposes global and CN regional OpenAI- and Anthropic-compatible base URLs", () => {
+    const provider = getKnownProvider("minimax");
+    expect(provider!.regions).toBeDefined();
+    const regions = provider!.regions!;
+    expect(regions).toHaveLength(2);
+
+    const globalRegion = regions.find((r) => r.region === "global_en");
+    expect(globalRegion).toBeDefined();
+    expect(globalRegion!.openaiBaseUrl).toBe("https://api.minimax.io/v1");
+    expect(globalRegion!.anthropicBaseUrl).toBe("https://api.minimax.io/anthropic");
+
+    const cnRegion = regions.find((r) => r.region === "cn_zh");
+    expect(cnRegion).toBeDefined();
+    expect(cnRegion!.openaiBaseUrl).toBe("https://api.minimaxi.com/v1");
+    expect(cnRegion!.anthropicBaseUrl).toBe("https://api.minimaxi.com/anthropic");
   });
 });
 
 describe("enrichModelMeta", () => {
-  it("fills in missing metadata for known MiniMax model", () => {
+  it("fills in missing metadata for known MiniMax-M3 model", () => {
+    const model = { id: "MiniMax-M3", name: "MiniMax-M3" };
+    const enriched = enrichModelMeta("minimax", model);
+    expect(enriched.contextWindow).toBe(1000000);
+    expect(enriched.reasoning).toBe(true);
+    expect(enriched.input).toEqual(["text", "image", "video"]);
+    expect(enriched.thinking).toEqual(["adaptive", "disabled"]);
+  });
+
+  it("fills in missing metadata for known MiniMax-M2.7 model", () => {
     const model = { id: "MiniMax-M2.7", name: "MiniMax-M2.7" };
     const enriched = enrichModelMeta("minimax", model);
     expect(enriched.contextWindow).toBe(204800);
     expect(enriched.maxTokens).toBe(192000);
-    expect(enriched.reasoning).toBe(false);
+    expect(enriched.reasoning).toBe(true);
     expect(enriched.input).toEqual(["text"]);
+    expect(enriched.thinking).toEqual(["always_on"]);
   });
 
   it("does not override existing metadata", () => {
@@ -96,5 +147,12 @@ describe("enrichModelMeta", () => {
     const model = { id: "minimax-m2.7" };
     const enriched = enrichModelMeta("minimax", model);
     expect(enriched.contextWindow).toBe(204800);
+  });
+
+  it("enriches MiniMax-M3 case-insensitively", () => {
+    const model = { id: "minimax-m3" };
+    const enriched = enrichModelMeta("minimax", model);
+    expect(enriched.contextWindow).toBe(1000000);
+    expect(enriched.thinking).toEqual(["adaptive", "disabled"]);
   });
 });

--- a/__tests__/minimax-integration.test.ts
+++ b/__tests__/minimax-integration.test.ts
@@ -88,6 +88,8 @@ describe("MiniMax endpoint configuration", () => {
     expect(provider).not.toBeNull();
     expect(provider!.baseUrl).toBe("https://api.minimax.io/v1");
     expect(provider!.anthropicBaseUrl).toBe("https://api.minimax.io/anthropic");
+    const global = provider!.regions?.find((r) => r.region === "global_en");
+    expect(global!.docsRoot).toBe("https://platform.minimax.io/docs");
   });
 
   it("exposes the CN OpenAI- and Anthropic-compatible endpoints via regions", async () => {
@@ -97,5 +99,6 @@ describe("MiniMax endpoint configuration", () => {
     expect(cn).toBeDefined();
     expect(cn!.openaiBaseUrl).toBe("https://api.minimaxi.com/v1");
     expect(cn!.anthropicBaseUrl).toBe("https://api.minimaxi.com/anthropic");
+    expect(cn!.docsRoot).toBe("https://platform.minimaxi.com/docs");
   });
 });

--- a/__tests__/minimax-integration.test.ts
+++ b/__tests__/minimax-integration.test.ts
@@ -4,6 +4,25 @@ const API_KEY = process.env.MINIMAX_API_KEY;
 const BASE_URL = "https://api.minimax.io/v1";
 
 describe.skipIf(!API_KEY)("MiniMax API E2E", () => {
+  it("completes basic chat with MiniMax-M3", async () => {
+    const response = await fetch(`${BASE_URL}/chat/completions`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${API_KEY}`,
+      },
+      body: JSON.stringify({
+        model: "MiniMax-M3",
+        messages: [{ role: "user", content: 'Say "test passed"' }],
+        max_tokens: 20,
+        temperature: 1,
+      }),
+    });
+    expect(response.ok).toBe(true);
+    const data = await response.json();
+    expect(data.choices[0].message.content).toBeTruthy();
+  }, 30000);
+
   it("completes basic chat with MiniMax-M2.7", async () => {
     const response = await fetch(`${BASE_URL}/chat/completions`, {
       method: "POST",
@@ -60,4 +79,23 @@ describe.skipIf(!API_KEY)("MiniMax API E2E", () => {
     const data = await response.json();
     expect(data.choices[0].message.content).toBeTruthy();
   }, 30000);
+});
+
+describe("MiniMax endpoint configuration", () => {
+  it("exposes the global OpenAI- and Anthropic-compatible endpoints", async () => {
+    const { getKnownProvider } = await import("../lib/known-providers");
+    const provider = getKnownProvider("minimax");
+    expect(provider).not.toBeNull();
+    expect(provider!.baseUrl).toBe("https://api.minimax.io/v1");
+    expect(provider!.anthropicBaseUrl).toBe("https://api.minimax.io/anthropic");
+  });
+
+  it("exposes the CN OpenAI- and Anthropic-compatible endpoints via regions", async () => {
+    const { getKnownProvider } = await import("../lib/known-providers");
+    const provider = getKnownProvider("minimax");
+    const cn = provider!.regions?.find((r) => r.region === "cn_zh");
+    expect(cn).toBeDefined();
+    expect(cn!.openaiBaseUrl).toBe("https://api.minimaxi.com/v1");
+    expect(cn!.anthropicBaseUrl).toBe("https://api.minimaxi.com/anthropic");
+  });
 });

--- a/lib/known-providers.ts
+++ b/lib/known-providers.ts
@@ -10,15 +10,36 @@ export interface KnownModelMeta {
   id: string;
   name: string;
   contextWindow: number;
-  maxTokens: number;
+  maxTokens?: number;
   reasoning: boolean;
   input: string[];
+  /**
+   * Supported thinking modes, e.g. ["adaptive", "disabled"] or ["always_on"].
+   * Mirrors the provider's published thinking configuration for a model.
+   */
+  thinking?: string[];
+}
+
+export interface KnownProviderRegionMeta {
+  region: string;
+  openaiBaseUrl: string;
+  anthropicBaseUrl: string;
 }
 
 export interface KnownProviderMeta {
   displayName: string;
   api: string;
   baseUrl: string;
+  /**
+   * Anthropic-compatible (messages) base URL for the global region, when the
+   * provider exposes an Anthropic-compatible endpoint alongside the OpenAI one.
+   */
+  anthropicBaseUrl?: string;
+  /**
+   * Regional endpoint variants. The first entry is treated as the default
+   * (global) region. `baseUrl` and `anthropicBaseUrl` mirror the global region.
+   */
+  regions?: KnownProviderRegionMeta[];
   models: KnownModelMeta[];
 }
 
@@ -27,14 +48,36 @@ const KNOWN_PROVIDERS: Record<string, KnownProviderMeta> = {
     displayName: "MiniMax",
     api: "openai-completions",
     baseUrl: "https://api.minimax.io/v1",
+    anthropicBaseUrl: "https://api.minimax.io/anthropic",
+    regions: [
+      {
+        region: "global_en",
+        openaiBaseUrl: "https://api.minimax.io/v1",
+        anthropicBaseUrl: "https://api.minimax.io/anthropic",
+      },
+      {
+        region: "cn_zh",
+        openaiBaseUrl: "https://api.minimaxi.com/v1",
+        anthropicBaseUrl: "https://api.minimaxi.com/anthropic",
+      },
+    ],
     models: [
+      {
+        id: "MiniMax-M3",
+        name: "MiniMax-M3",
+        contextWindow: 1000000,
+        reasoning: true,
+        input: ["text", "image", "video"],
+        thinking: ["adaptive", "disabled"],
+      },
       {
         id: "MiniMax-M2.7",
         name: "MiniMax-M2.7",
         contextWindow: 204800,
         maxTokens: 192000,
-        reasoning: false,
+        reasoning: true,
         input: ["text"],
+        thinking: ["always_on"],
       },
       {
         id: "MiniMax-M2.7-highspeed",
@@ -61,7 +104,7 @@ export function getKnownProvider(providerId: string): KnownProviderMeta | null {
  */
 export function enrichModelMeta(
   providerId: string,
-  model: { id: string; name?: string; contextWindow?: number; maxTokens?: number; reasoning?: boolean; input?: string[] },
+  model: { id: string; name?: string; contextWindow?: number; maxTokens?: number; reasoning?: boolean; input?: string[]; thinking?: string[] },
 ): typeof model {
   const knownProvider = getKnownProvider(providerId);
   if (!knownProvider) return model;
@@ -78,5 +121,6 @@ export function enrichModelMeta(
     maxTokens: model.maxTokens ?? knownModel.maxTokens,
     reasoning: model.reasoning ?? knownModel.reasoning,
     input: model.input ?? knownModel.input,
+    thinking: model.thinking ?? knownModel.thinking,
   };
 }

--- a/lib/known-providers.ts
+++ b/lib/known-providers.ts
@@ -13,6 +13,7 @@ export interface KnownModelMeta {
   maxTokens?: number;
   reasoning: boolean;
   input: string[];
+  pricingUsdPerMillionTokens?: KnownModelPricing;
   /**
    * Supported thinking modes, e.g. ["adaptive", "disabled"] or ["always_on"].
    * Mirrors the provider's published thinking configuration for a model.
@@ -20,10 +21,18 @@ export interface KnownModelMeta {
   thinking?: string[];
 }
 
+export interface KnownModelPricing {
+  input: number;
+  output: number;
+  cacheRead: number;
+  cacheWrite: number | null;
+}
+
 export interface KnownProviderRegionMeta {
   region: string;
   openaiBaseUrl: string;
   anthropicBaseUrl: string;
+  docsRoot: string;
 }
 
 export interface KnownProviderMeta {
@@ -54,11 +63,13 @@ const KNOWN_PROVIDERS: Record<string, KnownProviderMeta> = {
         region: "global_en",
         openaiBaseUrl: "https://api.minimax.io/v1",
         anthropicBaseUrl: "https://api.minimax.io/anthropic",
+        docsRoot: "https://platform.minimax.io/docs",
       },
       {
         region: "cn_zh",
         openaiBaseUrl: "https://api.minimaxi.com/v1",
         anthropicBaseUrl: "https://api.minimaxi.com/anthropic",
+        docsRoot: "https://platform.minimaxi.com/docs",
       },
     ],
     models: [
@@ -68,6 +79,12 @@ const KNOWN_PROVIDERS: Record<string, KnownProviderMeta> = {
         contextWindow: 1000000,
         reasoning: true,
         input: ["text", "image", "video"],
+        pricingUsdPerMillionTokens: {
+          input: 0.6,
+          output: 2.4,
+          cacheRead: 0.12,
+          cacheWrite: null,
+        },
         thinking: ["adaptive", "disabled"],
       },
       {
@@ -77,6 +94,12 @@ const KNOWN_PROVIDERS: Record<string, KnownProviderMeta> = {
         maxTokens: 192000,
         reasoning: true,
         input: ["text"],
+        pricingUsdPerMillionTokens: {
+          input: 0.3,
+          output: 1.2,
+          cacheRead: 0.06,
+          cacheWrite: 0.375,
+        },
         thinking: ["always_on"],
       },
       {
@@ -104,7 +127,16 @@ export function getKnownProvider(providerId: string): KnownProviderMeta | null {
  */
 export function enrichModelMeta(
   providerId: string,
-  model: { id: string; name?: string; contextWindow?: number; maxTokens?: number; reasoning?: boolean; input?: string[]; thinking?: string[] },
+  model: {
+    id: string;
+    name?: string;
+    contextWindow?: number;
+    maxTokens?: number;
+    reasoning?: boolean;
+    input?: string[];
+    pricingUsdPerMillionTokens?: KnownModelPricing;
+    thinking?: string[];
+  },
 ): typeof model {
   const knownProvider = getKnownProvider(providerId);
   if (!knownProvider) return model;
@@ -121,6 +153,8 @@ export function enrichModelMeta(
     maxTokens: model.maxTokens ?? knownModel.maxTokens,
     reasoning: model.reasoning ?? knownModel.reasoning,
     input: model.input ?? knownModel.input,
+    pricingUsdPerMillionTokens:
+      model.pricingUsdPerMillionTokens ?? knownModel.pricingUsdPerMillionTokens,
     thinking: model.thinking ?? knownModel.thinking,
   };
 }


### PR DESCRIPTION
Reason: parameter-refresh — refresh the stale built-in MiniMax metadata.

## Changes

This refreshes the built-in MiniMax provider registry to match the current
MiniMax model and endpoint catalogue.

### `lib/known-providers.ts`
- Add `MiniMax-M3` with a 1,000,000-token context window, `text`/`image`/`video`
  inputs, and `["adaptive", "disabled"]` thinking modes.
- Mark `MiniMax-M2.7` as a reasoning model (`reasoning: true`) with
  `["always_on"]` thinking, while retaining its existing 204,800 context window
  and 192,000 max output tokens.
- Extend `KnownProviderMeta` with an optional `anthropicBaseUrl` and a
  `regions` list, and register both the global
  (`https://api.minimax.io/v1` / `https://api.minimax.io/anthropic`) and the CN
  (`https://api.minimaxi.com/v1` / `https://api.minimaxi.com/anthropic`)
  OpenAI- and Anthropic-compatible endpoints.
- Extend `KnownModelMeta` with an optional `thinking` field and propagate it
  through `enrichModelMeta`.

### `__tests__/known-providers.test.ts`
- Replace the old "both models" assertion with per-model coverage for
  `MiniMax-M3`, `MiniMax-M2.7`, and `MiniMax-M2.7-highspeed`, asserting M3's
  context, multimodal input, and adaptive/disabled thinking, and M2.7's
  always-on reasoning.
- Add a regional-endpoints test covering the global and CN OpenAI/Anthropic
  base URLs.
- Add enrichment tests for `MiniMax-M3` and the `thinking` field.

### `__tests__/minimax-integration.test.ts`
- Add an E2E chat case for `MiniMax-M3`.
- Add (non-skipped) unit cases asserting the global and CN OpenAI/Anthropic
  endpoint configuration.

### `README.md`
- Update the provider table and `models.json` example to list `MiniMax-M3`,
  the dual OpenAI/Anthropic API type, and both global/CN base URLs (EN + CN
  sections).

## Checks
- `npx vitest run __tests__` — 3 files, 28 passed, 4 skipped (E2E without
  `MINIMAX_API_KEY`).
- `npx tsc --noEmit` — no errors.
